### PR TITLE
Do not refer to refs/for/* anymore

### DIFF
--- a/Documentation/GitSetup/Index.rst
+++ b/Documentation/GitSetup/Index.rst
@@ -97,7 +97,7 @@ Once you are happy with your changes, you can push them via
 
 .. code-block:: bash
 
-   git push origin HEAD:refs/for/master
+   git push origin HEAD:refs/publish/master
 
 .. note::
 
@@ -105,7 +105,7 @@ Once you are happy with your changes, you can push them via
 
    .. code-block:: bash
 
-      git push Gerrit HEAD:refs/for/master
+      git push Gerrit HEAD:refs/publish/master
 
 Other resources
 ===============


### PR DESCRIPTION
This is deprecated in recent Gerrit versions.
One should use refs/draft/* or refs/publish/*